### PR TITLE
Make ppd a standalone executable, no need to source it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+PREFIX ?= /usr
+
+all:
+	@echo RUN \'make install\' to install ppd
+	@echo RUN \'make uninstall\' to uninstall ppd
+
+install:
+	@install -Dm755 ppd $(DESTDIR)$(PREFIX)/bin/ppd
+
+uninstall:
+	@rm -f $(DESTDIR)$(PREFIX)/bin/ppd

--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@ ppd is a pushd/popd alternative written in bash
 
 ## Usage
 
-Setup:
-
-```bash
-root:@/home $ . /usr/local/bin/ppd
-```
-
 Usage:
 
 ```bash
@@ -58,9 +52,14 @@ directory stack empty
 ## Installation
 
 ```bash
-$ curl -O https://raw.githubusercontent.com/paololazzari/ppd/master/ppd
-$ cp ppd /usr/local/bin/ppd
-$ . /usr/local/bin/ppd
+$ git clone https://github.com/paololazzari/ppd; cd ppd
+$ sudo make install
 ```
 
-consider adding the last command to your $HOME/.bashrc
+## Unistallation
+
+In the directory where you cloned the repository
+
+```bash
+$ sudo make uninstall
+```

--- a/ppd
+++ b/ppd
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 VERSION="0.1.1"
 
-_print_version()
+print_version()
 {
   echo "ppd version $VERSION"
 }
 
-_print_options()
+print_options()
 {
   echo "Commands: "
   echo "  list                         : List dir stack"
@@ -22,12 +22,12 @@ _print_options()
 
 PPDSTACK=("$(pwd)")
 
-_uniques() {
+uniques() {
   # get unique entries from the stack
   printf "%s\n" "${PPDSTACK[@]}" | awk '!seen[$0]++'
 }
 
-_add() {
+add() {
   # add one or more directories to the stack
   if [ "$#" -eq 0 ]; then
     PPDSTACK+=("$(pwd)")
@@ -43,12 +43,12 @@ _add() {
   fi
 }
 
-_clear() {
+clear() {
   # clear the stack
   PPDSTACK=()
 }
 
-_go() {
+go() {
   # navigate to a directory in the stack
   if [ "${#PPDSTACK[@]}" -eq 0 ]; then
     echo "directory stack empty"
@@ -83,7 +83,7 @@ _go() {
   done
 }
 
-_list(){
+list(){
   # print all entries in the stack
   if [ "${#PPDSTACK[@]}" -eq 0 ]; then
     echo "directory stack empty"
@@ -94,7 +94,7 @@ _list(){
   fi
 }
 
-_pop() {
+pop() {
   # pop last directory from the stack
   if [ "${#PPDSTACK[@]}" -eq 0 ]; then
     echo "directory stack empty"
@@ -107,7 +107,7 @@ _pop() {
   fi
 }
 
-_push(){
+push(){
   # push one or more directories to the stack
   l="${#PPDSTACK[@]}"
   if [ "$#" -eq 0 ]; then
@@ -127,7 +127,7 @@ _push(){
   fi
 }
 
-_remove(){
+remove(){
   # remove one or more directories from the stack
   if [ "${#PPDSTACK[@]}" -eq 0 ]; then
     echo "directory stack empty"
@@ -156,53 +156,53 @@ _remove(){
   fi
 }
 
-_usage() {
+usage() {
   echo "Error: Must specify at least one command"
   echo "Usage: ppd [COMMAND]"
   echo "       ppd [-h | -v ]"
-  _print_options
+  print_options
 }
 
 ppd(){
   # parse command line arguments
   if [[ "$#" -eq 0 ]]; then
-    _usage
+    usage
   else
     while [[ "$#" -gt 0 ]]; do
         case $1 in
-            -h|--help) _print_options; break ;;
-            -v|--version) _print_version; break;;
+            -h|--help) print_options; break ;;
+            -v|--version) print_version; break;;
             add)
               shift
-              _add "$@";
+              add "$@";
               break ;;
             clear)
               if [ "$#" -gt 1 ]; then echo "ppd clear takes no arguments" && break; fi
-              _clear;
+              clear;
               break ;;
             go)
               shift
               if [ "$#" -gt 1 ]; then echo "ppd go takes zero or one arguments" && break; fi
               if [ "$#" -eq 1 ] && ! grep -qE '^[0-9]+$' <<<"$1"; then echo "argument must be a positive number" && break; fi
-              _go "$@";
+              go "$@";
               break ;;
             list)
               if [ "$#" -gt 1 ]; then echo "ppd list takes no arguments" && break; fi
-              _list;
+              list;
               break ;;
             pop)
               if [ "$#" -gt 1 ]; then echo "ppd pop takes no arguments" && break; fi
-              _pop;
+              pop;
               break ;;
             push)
               shift
-              _push "$@";
+              push "$@";
               break ;;
             remove)
               shift
               if [ "$#" -gt 1 ]; then echo "ppd remove takes zero or one arguments" && break; fi
               if [ "$#" -eq 1 ] && ! grep -qE '^[0-9]+$' <<<"$1"; then echo "argument must be a positive number" && break; fi
-              _remove "$@";
+              remove "$@";
               break;;
             *) echo "Unknown parameter passed: $1";;
         esac

--- a/ppd
+++ b/ppd
@@ -210,3 +210,5 @@ ppd(){
     done
   fi
 }
+
+ppd "$@"


### PR DESCRIPTION
I also added a Makefile to make installing/uninstalling it simpler and edited the README.md so it reflects the changes.

The function names have been changed too, since if the user doesn't source it in their shell's config file, the functions don't have to be prefixed with and underscore.

I can also add examples of how to use the Makefile inside the README.md so that the user doesn't need to install it globally.